### PR TITLE
1.19 fix null pointers when strengthening unknown mobs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.14.9
 
 # Mod Properties
-	mod_version = 1.3.0
+	mod_version = 1.3.1
 	maven_group = net.rpgdifficulty
 	archives_base_name = rpgdifficulty
 

--- a/src/main/java/net/rpgdifficulty/api/MobStrengthener.java
+++ b/src/main/java/net/rpgdifficulty/api/MobStrengthener.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 
 import net.fabricmc.fabric.mixin.object.builder.DefaultAttributeRegistryAccessor;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -178,15 +179,17 @@ public class MobStrengthener {
                 mobSpeed = Math.round(mobSpeed * 1000.0D) / 1000.0D;
             }
 
+            DefaultAttributeContainer mobEntityDefaultAttributes = DefaultAttributeRegistryAccessor.getRegistry().get(mobEntity.getType());
+
             // Test purpose
             if (RpgDifficultyMain.CONFIG.hudTesting) {
                 System.out.println(Registry.ENTITY_TYPE.getId(mobEntity.getType()).toString() + "; HealthFactor: " + mobHealthFactor + "; DamageFactor: " + mobDamageFactor + "; Health: " + mobHealth
                         + ";  Old Health: " + mobEntity.getHealth() + "; Default HP: "
-                        + DefaultAttributeRegistryAccessor.getRegistry().get(mobEntity.getType()).getBaseValue(EntityAttributes.GENERIC_MAX_HEALTH));
+                        + (mobEntityDefaultAttributes != null ? mobEntityDefaultAttributes.getBaseValue(EntityAttributes.GENERIC_MAX_HEALTH) : "-"));
             }
 
             // Check if mob already has increased strength
-            if (mobHealth - DefaultAttributeRegistryAccessor.getRegistry().get(mobEntity.getType()).getBaseValue(EntityAttributes.GENERIC_MAX_HEALTH) * mobHealthFactor < 0.1D) {
+            if (mobEntityDefaultAttributes != null && mobHealth - mobEntityDefaultAttributes.getBaseValue(EntityAttributes.GENERIC_MAX_HEALTH) * mobHealthFactor < 0.1D) {
                 // Set Values
                 mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(mobHealth);
                 mobEntity.heal(mobEntity.getMaxHealth());


### PR DESCRIPTION
Hello @Globox1997!

Just adding a small guard against accessing the default attributes, since it's sometimes crashing when encountering mobs of unknown types (such as those added by other mods), after the latest update.

Let me know what you think