### PR TITLE
Updated jitpack.yml to use Java 17

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,5 @@
+jdk:
+  - openjdk17
 before_install:
-  - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
-  - source install-jdk.sh --feature 17
+  - sdk install java 17.0.3-tem
+  - sdk use java 17.0.3-tem


### PR DESCRIPTION
Referencing issue #51 

My `mim1q/RpgDifficulty` fork builds successfully: [log](https://jitpack.io/com/github/mim1q/RpgDifficulty/1.19-894c1af28b-1/build.log)