### PR TITLE
Exclude Bumblezone Cosmic Crystal by default in config

### DIFF
--- a/src/main/java/net/rpgdifficulty/config/RpgDifficultyConfig.java
+++ b/src/main/java/net/rpgdifficulty/config/RpgDifficultyConfig.java
@@ -1,6 +1,7 @@
 package net.rpgdifficulty.config;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
@@ -79,7 +80,7 @@ public class RpgDifficultyConfig implements ConfigData {
     public boolean hudTesting = false;
 
     @Comment("Excluded Entity List Bsp: minecraft:villager")
-    public ArrayList<String> excludedEntity = new ArrayList<String>();
+    public ArrayList<String> excludedEntity = new ArrayList<String>(List.of("the_bumblezone:cosmic_crystal_entity"));
 
     @ConfigEntry.Category("monster_setting")
     public boolean allowSpecialZombie = true;


### PR DESCRIPTION
I had some time and did this through the browser so wasn't able to test this. Since the field requires an ArrayList, I assume list had to be mutable. So did List.of to make list of the strings easily and then feed that to arraylist.

Should help prevent people from being confused as to why they cannot beat my boss by preventing it from getting scaled health by default. Helps server as an example too for how to exclude modded entities.